### PR TITLE
Parser cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,6 +2,9 @@
 multifiledownloader-rs/
 /NolvusDashboard/*
 /NolvusDashboard
-downloads/
+downloads/*
+/downloads
+w
 wabbajack/
 .env
+examples/downloads/*

--- a/crates/installer/Cargo.toml
+++ b/crates/installer/Cargo.toml
@@ -68,29 +68,7 @@ wiremock = "0.6"
 tracing-subscriber = "0.3"
 http = "0.2"
 
-[[example]]
-name = "structured_download_example"
-path = "../../examples/structured_download_example.rs"
 
-[[example]]
-name = "parse_baseline_example"
-path = "../../examples/parse_baseline_example.rs"
-
-[[example]]
-name = "wabbajack_cdn_example"
-path = "../../examples/wabbajack_cdn_example.rs"
-
-[[example]]
-name = "size_progress_example"
-path = "../../examples/size_progress_example.rs"
-
-[[example]]
-name = "gamefile_example"
-path = "../../examples/gamefile_example.rs"
-
-[[example]]
-name = "simple_baseline_download"
-path = "../../examples/simple_baseline_download.rs"
 
 [[example]]
 name = "hp_bl_dl"

--- a/crates/installer/src/downloader/core/validation.rs
+++ b/crates/installer/src/downloader/core/validation.rs
@@ -63,10 +63,9 @@ pub struct FileValidation {
 impl FileValidation {
     pub fn new(hash: String, size: u64) -> Self {
         Self {
-            xxhash64_base64: Some(hash),
+            xxhash64_base64: if hash.is_empty() { None } else { Some(hash) },
             expected_size: Some(size),
         }
-
     }
     /// Check if validation is needed
     pub fn is_empty(&self) -> bool {

--- a/debug_hash.rs
+++ b/debug_hash.rs
@@ -1,23 +1,29 @@
 use base64;
 
 fn main() {
-    let base64_hash = "h5C1sOVi8K8=";
-    let actual_hash = "5e67475585765e6b9e90904efabd972d";
+    let test_data = b"Hello, World!";
 
-    // Decode base64 to bytes then to hex
-    match base64::decode(base64_hash) {
+    // Calculate xxHash64 of data and return as base64 string (matching Wabbajack format)
+    let hash = xxhash_rust::xxh64::xxh64(test_data, 0);
+    let bytes = hash.to_le_bytes();
+    let base64_hash = base64::Engine::encode(&base64::engine::general_purpose::STANDARD, &bytes);
+
+    println!("Content: {:?}", std::str::from_utf8(test_data).unwrap());
+    println!("XXHash64: {}", hash);
+    println!("Base64 hash: {}", base64_hash);
+
+    // Also check what "dGVzdA==" decodes to
+    let wrong_hash = "dGVzdA==";
+    match base64::Engine::decode(&base64::engine::general_purpose::STANDARD, wrong_hash) {
         Ok(bytes) => {
-            let hex_from_base64 = bytes.iter()
-                .map(|b| format!("{:02x}", b))
-                .collect::<String>();
-
-            println!("Base64 hash: {}", base64_hash);
-            println!("Decoded to hex: {}", hex_from_base64);
-            println!("Actual computed hash: {}", actual_hash);
-            println!("Match: {}", hex_from_base64 == actual_hash);
+            if let Ok(decoded) = std::str::from_utf8(&bytes) {
+                println!("\"dGVzdA==\" decodes to: {:?}", decoded);
+            } else {
+                println!("\"dGVzdA==\" decodes to bytes: {:?}", bytes);
+            }
         }
         Err(e) => {
-            println!("Error decoding base64: {}", e);
+            println!("Error decoding dGVzdA==: {}", e);
         }
     }
 }


### PR DESCRIPTION
Uses Serde From to make an parser implementation for the DownloadSource enum. Now DownloadSources are created during parsing. 